### PR TITLE
Turn class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ## War or Peace
+
+https://backend.turing.edu/module1/projects/war_or_peace/
+
 ### Mentors
 This project is given with intent to work through with mentors at least twice through its duration.  The following are interactions I had with both Heidi and Jonathan:
 
@@ -8,7 +11,8 @@ This project is given with intent to work through with mentors at least twice th
 - We started working on the rank_of_card_at method.  I couldn't figure out how to start this and with some loose guiding we got there.  I'm still struggling to create a method without help starting it.  I don't know why this concept is so difficult for me to get on my own.  
 
 - I find myself not thinking very clearly when I work through things with a mentor after classes.  My brain and logic muscles are tired! We are working on scheduling some things earlier in the mornings and this week we will plan on meeting again on Friday when we both have time off and flexibility to meet in the middle of the day. 
-- 
+
+- It's been helpful to shoot quick messages to Heidi.  Most times I just need a little help, not a 30-60 minute session.  It's the quick things that can hold me up for so long.   
 
 ### Project reflections
 What worked well for me in this project?

--- a/lib/deck.rb
+++ b/lib/deck.rb
@@ -1,5 +1,5 @@
 class Deck
-  attr_reader :cards 
+  attr_accessor :cards 
   
   def initialize(cards)
     @cards = cards

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -9,6 +9,7 @@ class Player
 
   def has_lost?
     deck == []
+    # or deck.empty?
   end
 end
 

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -1,6 +1,6 @@
 class Player
-  attr_reader :name,
-              :deck
+  attr_reader :name
+  attr_accessor :deck
               
   def initialize(name, deck)
     @name = name

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -14,7 +14,7 @@ class Turn
       :basic
     elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)
       :war 
-    else #don't NEED an else statement.  But it seems like I do need the conditional here. 
+    else #don't NEED an else statement.  But it seems like I do need the conditional here: 
 
     # else player1.rank_of_card_at(0) == player2.rank_of_card_at(0) && player1.rank_of_card_at(0) == player2.rank_of_card_at(2)
       :mutually_assured_destruction
@@ -24,8 +24,19 @@ class Turn
   def winner
     if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0) == true
       player1
+      # later:     if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0) || if player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0) == true
     else
       player2
+    end
+  end
+
+  def pile_cards
+    if self.type == :basic
+      @spoils_of_war << player1.deck.cards[0]
+      @spoils_of_war << player2.deck.cards[0]
+
+      #remove_card from player1 and player2
+      #that card will go into the @spoils_of_war array
     end
   end
 

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -14,17 +14,22 @@ class Turn
       :basic
     elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)
       :war 
-    else #don't NEED an else statement.  But it seems like I do need the conditional here: 
+     #don't NEED an else statement.  But it seems like I do need the conditional here: 
 
-    # else player1.rank_of_card_at(0) == player2.rank_of_card_at(0) && player1.rank_of_card_at(0) == player2.rank_of_card_at(2)
+    elsif player1.rank_of_card_at(0) == player2.rank_of_card_at(0) && player1.rank_of_card_at(0) == player2.rank_of_card_at(2)
       :mutually_assured_destruction
     end
   end
 
+  #can I fit all types in this winner method or do I need to do a #basic_winner #war_winner as helper methods?
   def winner
+    #basic
     if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0) == true
+      player1 
+
+    #war
+    elsif (player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)) == true && (player1.deck.rank_of_card_at(2) > player2.deck.rank_of_card_at(2))
       player1
-      # later:     if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0) || if player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0) == true
     else
       player2
     end
@@ -34,9 +39,9 @@ class Turn
     if self.type == :basic
       @spoils_of_war << player1.deck.cards[0]
       @spoils_of_war << player2.deck.cards[0]
-
-      #remove_card from player1 and player2
-      #that card will go into the @spoils_of_war array
+    elsif self.type == :war
+      @spoils_of_war.concat(player1.deck.cards[0..2].flatten)
+      @spoils_of_war.concat(player2.deck.cards[0..2].flatten)
     end
   end
 

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -12,11 +12,13 @@ class Turn
   def type
     if player1.deck.rank_of_card_at(0) != player2.deck.rank_of_card_at(0)
       :basic
-    elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)
+    elsif 
+      player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0) && player1.deck.rank_of_card_at(2) != player2.deck.rank_of_card_at(2)
       :war 
-     #don't NEED an else statement.  But it seems like I do need the conditional here: 
+     # per Heidi don't NEED an else statement.  But it seems like I do need the conditional here: 
 
-    elsif player1.rank_of_card_at(0) == player2.rank_of_card_at(0) && player1.rank_of_card_at(0) == player2.rank_of_card_at(2)
+    elsif 
+       player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0) && player1.deck.rank_of_card_at(2) == player2.deck.rank_of_card_at(2)
       :mutually_assured_destruction
     end
   end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -41,9 +41,11 @@ class Turn
   end
 
   def award_spoils(winner)
-    winner.deck << @spoils_of_war[0]
-    #add cards in @spoils_of_war array to the winner of the turn
+    winner.deck << @spoils_of_war[0] 
+    winner.deck << @spoils_of_war[1]
+    #add cards in @spoils_of_war array to the deck of winner of the turn
 
+    #attr_accessor?  But why didn't I need it in #pile_cards
     #.append?
   end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -41,11 +41,19 @@ class Turn
   end
 
   def award_spoils(winner)
-    winner.deck << @spoils_of_war[0] 
-    winner.deck << @spoils_of_war[1]
+    # @spoils_of_war.each do |card|
+      winner.deck.cards.concat(@spoils_of_war)
+      @spoils_of_war = []
+      # winner.deck.cards.unshift(card)
+    # end
     #add cards in @spoils_of_war array to the deck of winner of the turn
 
-    #attr_accessor?  But why didn't I need it in #pile_cards
+    # winner.deck.cards << @spoils_of_war[0] 
+    # winner.deck.cards << @spoils_of_war[1]
+    #can I use this ^ since there will only be two cards in #s_o_w at any time?  Or should I iterate with ennumerable out of good practice?
+
+    # tried this in ine 45: `winner.deck.cards.unshift(card)``
+    #attr_accessor in Deck class?  But why didn't I need it in #pile_cards
     #.append?
   end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -10,14 +10,23 @@ class Turn
   end
 
   def type
-    require 'pry' ; binding.pry
-    if player1.deck.rank_of_card_at(0) != player2.rank_of_card_at(0)
-      puts :basic
-    elsif player1.deck.rank_of_card_at(0) == player2.rank_of_card_at(0)
-      puts :war 
-    else
+    if player1.deck.rank_of_card_at(0) != player2.deck.rank_of_card_at(0)
+      :basic
+    elsif player1.deck.rank_of_card_at(0) == player2.deck.rank_of_card_at(0)
+      :war 
+    else #don't NEED an else statement.  But it seems like I do need the conditional here. 
+
     # else player1.rank_of_card_at(0) == player2.rank_of_card_at(0) && player1.rank_of_card_at(0) == player2.rank_of_card_at(2)
-      puts :mutually_assured_destruction
+      :mutually_assured_destruction
     end
   end
+
+  def winner
+    if player1.deck.rank_of_card_at(0) > player2.deck.rank_of_card_at(0) == true
+      player1
+    else
+      player2
+    end
+  end
+
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,0 +1,8 @@
+class Turn 
+  attr_reader :player1, :player2
+
+  def initialize(player1, player2)
+    @player1 = player1
+    @player2 = player2
+  end
+end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -40,4 +40,10 @@ class Turn
     end
   end
 
+  def award_spoils(winner)
+    winner.deck << @spoils_of_war[0]
+    #add cards in @spoils_of_war array to the winner of the turn
+
+    #.append?
+  end
 end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,8 +1,23 @@
 class Turn 
-  attr_reader :player1, :player2
+  attr_reader :player1, 
+              :player2, 
+              :spoils_of_war
 
   def initialize(player1, player2)
     @player1 = player1
     @player2 = player2
+    @spoils_of_war = []
+  end
+
+  def type
+    require 'pry' ; binding.pry
+    if player1.deck.rank_of_card_at(0) != player2.rank_of_card_at(0)
+      puts :basic
+    elsif player1.deck.rank_of_card_at(0) == player2.rank_of_card_at(0)
+      puts :war 
+    else
+    # else player1.rank_of_card_at(0) == player2.rank_of_card_at(0) && player1.rank_of_card_at(0) == player2.rank_of_card_at(2)
+      puts :mutually_assured_destruction
+    end
   end
 end

--- a/spec/deck_spec.rb
+++ b/spec/deck_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Deck do
       cards = [card1, card2, card3]
       deck = Deck.new(cards)
 
-      deck.high_ranking_cards
+      # deck.high_ranking_cards
       expect(deck.high_ranking_cards).to eq([card1, card3])
     end
 

--- a/spec/deck_spec.rb
+++ b/spec/deck_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Deck do
       deck = Deck.new(cards)
 
       deck.percent_high_ranking
-
       expect(deck.percent_high_ranking).to eq(66.67)
     end
   end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Turn do
       expect(turn.spoils_of_war).to eq([card1, card3])
       
       turn.award_spoils(winner)
-      expect(player1.deck).to eq([card1, card2, card3, card5, card8])
-      expect(player2.deck).to eq([card4, card6, card7])
+      expect(player1.deck).to eq(deck1)
+      expect(player2.deck).to eq(deck2)
       end
     end
   end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -7,9 +7,23 @@ require './lib/turn'
 RSpec.describe Turn do
   describe 'initialize' do
     it 'exists' do
+      card1 = Card.new(:heart, 'Jack', 11)
+      card2 = Card.new(:heart, '10', 10)    
+      card3 = Card.new(:heart, '9', 9)    
+      card4 = Card.new(:diamond, 'Jack', 11)    
+      card5 = Card.new(:heart, '8', 8)    
+      card6 = Card.new(:diamond, 'Queen', 12)    
+      card7 = Card.new(:heart, '3', 3)    
+      card8 = Card.new(:diamond, '2', 2)    
+      deck1 = Deck.new([card1, card2, card5, card8])    
+      deck2 = Deck.new([card3, card4, card6, card7])    
+      player1 = Player.new("Megan", deck1)    
+      player2 = Player.new("Aurora",deck2)
       turn = Turn.new(player1, player2)    
 
-      expect(turn).to be a Turn
+      expect(turn).to be_an_instance_of(Turn)
+      expect(turn.player1).to eq(player1)
+      expect(turn.player2).to eq(player2)
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe Turn do
 
     describe 'has types of turns' do
       it 'has a :basic type of turn' do
+        card1 = Card.new(:heart, 'Jack', 11)
+        card2 = Card.new(:heart, '10', 10)    
+        card3 = Card.new(:heart, '9', 9)    
+        card4 = Card.new(:diamond, 'Jack', 11)    
+        card5 = Card.new(:heart, '8', 8)    
+        card6 = Card.new(:diamond, 'Queen', 12)    
+        card7 = Card.new(:heart, '3', 3)    
+        card8 = Card.new(:diamond, '2', 2)    
+        deck1 = Deck.new([card1, card2, card5, card8])    
+        deck2 = Deck.new([card3, card4, card6, card7])    
+        player1 = Player.new("Megan", deck1)    
+        player2 = Player.new("Aurora",deck2)
+        turn = Turn.new(player1, player2) 
+        
+        expect(turn.type).to eq(:basic)
+      end
+    end
+
+    describe 'has a winner' do
+      it "#winner" do
       card1 = Card.new(:heart, 'Jack', 11)
       card2 = Card.new(:heart, '10', 10)    
       card3 = Card.new(:heart, '9', 9)    
@@ -42,8 +62,8 @@ RSpec.describe Turn do
       player1 = Player.new("Megan", deck1)    
       player2 = Player.new("Aurora",deck2)
       turn = Turn.new(player1, player2) 
-        
-      expect(turn.type).to eq(:basic)
+
+      expect(turn.winner).to eq(player1)
       end
     end
   end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -26,29 +26,11 @@ RSpec.describe Turn do
       expect(turn.player2).to eq(player2)
       expect(turn.spoils_of_war).to eq([])
     end
+  end
 
-    describe 'has types of turns' do
-      it 'has a :basic type of turn' do
-        card1 = Card.new(:heart, 'Jack', 11)
-        card2 = Card.new(:heart, '10', 10)    
-        card3 = Card.new(:heart, '9', 9)    
-        card4 = Card.new(:diamond, 'Jack', 11)    
-        card5 = Card.new(:heart, '8', 8)    
-        card6 = Card.new(:diamond, 'Queen', 12)    
-        card7 = Card.new(:heart, '3', 3)    
-        card8 = Card.new(:diamond, '2', 2)    
-        deck1 = Deck.new([card1, card2, card5, card8])    
-        deck2 = Deck.new([card3, card4, card6, card7])    
-        player1 = Player.new("Megan", deck1)    
-        player2 = Player.new("Aurora",deck2)
-        turn = Turn.new(player1, player2) 
 
-        expect(turn.type).to eq(:basic)
-      end
-    end
-
-    describe 'has a winner and cards get shifted based on winner' do
-      it "#winner" do
+  describe 'has types of turns and game flow with winners' do
+    it 'has a :basic type of turn' do
       card1 = Card.new(:heart, 'Jack', 11)
       card2 = Card.new(:heart, '10', 10)    
       card3 = Card.new(:heart, '9', 9)    
@@ -63,33 +45,120 @@ RSpec.describe Turn do
       player2 = Player.new("Aurora",deck2)
       turn = Turn.new(player1, player2) 
 
+      expect(turn.type).to eq(:basic)
       expect(winner = turn.winner).to eq(player1)
-    end
-    
-    it 'shifts cards with #pile_cards and #award_spoils' do
-      card1 = Card.new(:heart, 'Jack', 11)
-      card2 = Card.new(:heart, '10', 10)    
-      card3 = Card.new(:heart, '9', 9)    
-      card4 = Card.new(:diamond, 'Jack', 11)    
-      card5 = Card.new(:heart, '8', 8)    
-      card6 = Card.new(:diamond, 'Queen', 12)    
-      card7 = Card.new(:heart, '3', 3)    
-      card8 = Card.new(:diamond, '2', 2)    
-      deck1 = Deck.new([card1, card2, card5, card8])    
-      deck2 = Deck.new([card3, card4, card6, card7])    
-      player1 = Player.new("Megan", deck1)    
-      player2 = Player.new("Aurora",deck2)
-      turn = Turn.new(player1, player2) 
+
       winner = turn.winner
-      
       turn.pile_cards
       
       expect(turn.spoils_of_war).to eq([card1, card3])
       
       turn.award_spoils(winner)
+
       expect(player1.deck).to eq(deck1)
       expect(player2.deck).to eq(deck2)
-      end
+    end
+
+    it "has a :war turn" do
+      card1 = Card.new(:heart, 'Jack', 11)    
+      card2 = Card.new(:heart, '10', 10)    
+      card3 = Card.new(:heart, '9', 9)    
+      card4 = Card.new(:diamond, 'Jack', 11)    
+      card5 = Card.new(:heart, '8', 8)    
+      card6 = Card.new(:diamond, 'Queen', 12)    
+      card7 = Card.new(:heart, '3', 3)    
+      card8 = Card.new(:diamond, '2', 2)    
+      deck1 = Deck.new([card1, card2, card5, card8])    
+      deck2 = Deck.new([card4, card3, card6, card7])    
+      player1 = Player.new("Megan", deck1)    
+      player2 = Player.new("Aurora", deck2)    
+      turn = Turn.new(player1, player2)  
+
+      expect(turn.type).to eq(:war)
+      winner = turn.winner
+      turn.pile_cards
+
+      expect(turn.spoils_of_war).to eq([card1, card2, card3, card4, card5, card6])
+
+      turn.award_spoils(winner)
+
+      expect(player1.deck).to eq(deck1)
+      expect(player2.deck).to eq(deck2)
+
+player2.deck
+
+
+    end
+
+    xit "has a :mutually_assured_destruction turn" do
+      card1 = Card.new(:heart, 'Jack', 11)    
+      card2 = Card.new(:heart, '10', 10)    
+      card3 = Card.new(:heart, '9', 9)    
+      card4 = Card.new(:diamond, 'Jack', 11)    
+      card5 = Card.new(:heart, '8', 8)    
+      card6 = Card.new(:diamond, '8', 8)    
+      card7 = Card.new(:heart, '3', 3)    
+      card8 = Card.new(:diamond, '2', 2)    
+      deck1 = Deck.new([card1, card2, card5, card8])    
+      deck2 = Deck.new([card4, card3, card6, card7])    
+      player1 = Player.new("Megan", deck1)    
+      player2 = Player.new("Aurora", deck2)    
+      turn = Turn.new(player1, player2)  
+      
+      expect(turn.type).to eq(:mutually_assured_destruction)
+      winner = turn.winner
+      turn.pile_cards
+      turn.spoils_of_war
+      player1.deck
+      player2.deck
     end
   end
 end
+
+  #I TOOK THIS BLOCK OUT AND PUT THE EXPECT LINE IN THE :BASIC TURN BLOCK
+  # describe 'has a winner and cards get shifted based on winner' do
+  #   it "#winner" do
+  #   card1 = Card.new(:heart, 'Jack', 11)
+  #   card2 = Card.new(:heart, '10', 10)    
+  #   card3 = Card.new(:heart, '9', 9)    
+  #   card4 = Card.new(:diamond, 'Jack', 11)    
+  #   card5 = Card.new(:heart, '8', 8)    
+  #   card6 = Card.new(:diamond, 'Queen', 12)    
+  #   card7 = Card.new(:heart, '3', 3)    
+  #   card8 = Card.new(:diamond, '2', 2)    
+  #   deck1 = Deck.new([card1, card2, card5, card8])    
+  #   deck2 = Deck.new([card3, card4, card6, card7])    
+  #   player1 = Player.new("Megan", deck1)    
+  #   player2 = Player.new("Aurora",deck2)
+  #   turn = Turn.new(player1, player2) 
+
+  #   expect(winner = turn.winner).to eq(player1)
+  # end
+  
+
+
+  #PUT THESE WINNER = TURN.WINNER, EXPECT STATEMENTS AND GAME FLOW IN :BASIC BLOCK
+  # it 'shifts cards with #pile_cards and #award_spoils' do
+  #   card1 = Card.new(:heart, 'Jack', 11)
+  #   card2 = Card.new(:heart, '10', 10)    
+  #   card3 = Card.new(:heart, '9', 9)    
+  #   card4 = Card.new(:diamond, 'Jack', 11)    
+  #   card5 = Card.new(:heart, '8', 8)    
+  #   card6 = Card.new(:diamond, 'Queen', 12)    
+  #   card7 = Card.new(:heart, '3', 3)    
+  #   card8 = Card.new(:diamond, '2', 2)    
+  #   deck1 = Deck.new([card1, card2, card5, card8])    
+  #   deck2 = Deck.new([card3, card4, card6, card7])    
+  #   player1 = Player.new("Megan", deck1)    
+  #   player2 = Player.new("Aurora",deck2)
+  #   turn = Turn.new(player1, player2) 
+  #   winner = turn.winner
+    
+  #   turn.pile_cards
+    
+  #   expect(turn.spoils_of_war).to eq([card1, card3])
+    
+  #   turn.award_spoils(winner)
+  #   expect(player1.deck).to eq(deck1)
+  #   expect(player2.deck).to eq(deck2)
+ 

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -78,19 +78,18 @@ RSpec.describe Turn do
       winner = turn.winner
       turn.pile_cards
 
-      expect(turn.spoils_of_war).to eq([card1, card2, card3, card4, card5, card6])
+      expect(turn.spoils_of_war).to eq([card1, card2, card5, card4, card3, card6])
 
       turn.award_spoils(winner)
 
       expect(player1.deck).to eq(deck1)
       expect(player2.deck).to eq(deck2)
 
-player2.deck
 
 
     end
 
-    xit "has a :mutually_assured_destruction turn" do
+    it "has a :mutually_assured_destruction turn" do
       card1 = Card.new(:heart, 'Jack', 11)    
       card2 = Card.new(:heart, '10', 10)    
       card3 = Card.new(:heart, '9', 9)    
@@ -102,15 +101,16 @@ player2.deck
       deck1 = Deck.new([card1, card2, card5, card8])    
       deck2 = Deck.new([card4, card3, card6, card7])    
       player1 = Player.new("Megan", deck1)    
-      player2 = Player.new("Aurora", deck2)    
+      player2 = Player.new("Aurora", deck2)  
       turn = Turn.new(player1, player2)  
       
       expect(turn.type).to eq(:mutually_assured_destruction)
       winner = turn.winner
       turn.pile_cards
-      turn.spoils_of_war
-      player1.deck
-      player2.deck
+
+      expect(turn.spoils_of_war).to eq([])
+      expect(player1.deck).to eq(deck1)
+      expect(player2.deck).to eq(deck2)
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -24,6 +24,27 @@ RSpec.describe Turn do
       expect(turn).to be_an_instance_of(Turn)
       expect(turn.player1).to eq(player1)
       expect(turn.player2).to eq(player2)
+      expect(turn.spoils_of_war).to eq([])
+    end
+
+    describe 'has types of turns' do
+      it 'has a :basic type of turn' do
+      card1 = Card.new(:heart, 'Jack', 11)
+      card2 = Card.new(:heart, '10', 10)    
+      card3 = Card.new(:heart, '9', 9)    
+      card4 = Card.new(:diamond, 'Jack', 11)    
+      card5 = Card.new(:heart, '8', 8)    
+      card6 = Card.new(:diamond, 'Queen', 12)    
+      card7 = Card.new(:heart, '3', 3)    
+      card8 = Card.new(:diamond, '2', 2)    
+      deck1 = Deck.new([card1, card2, card5, card8])    
+      deck2 = Deck.new([card3, card4, card6, card7])    
+      player1 = Player.new("Megan", deck1)    
+      player2 = Player.new("Aurora",deck2)
+      turn = Turn.new(player1, player2) 
+        
+      expect(turn.type).to eq(:basic)
+      end
     end
   end
 end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe Turn do
       player2 = Player.new("Aurora",deck2)
       turn = Turn.new(player1, player2) 
 
-      expect(turn.winner).to eq(player1)
-      end
-
-      it 'shifts cards with #pile_cards and #award_spoils' do
+      expect(winner = turn.winner).to eq(player1)
+    end
+    
+    it 'shifts cards with #pile_cards and #award_spoils' do
       card1 = Card.new(:heart, 'Jack', 11)
       card2 = Card.new(:heart, '10', 10)    
       card3 = Card.new(:heart, '9', 9)    
@@ -80,15 +80,15 @@ RSpec.describe Turn do
       player1 = Player.new("Megan", deck1)    
       player2 = Player.new("Aurora",deck2)
       turn = Turn.new(player1, player2) 
-
+      winner = turn.winner
+      
       turn.pile_cards
-
+      
       expect(turn.spoils_of_war).to eq([card1, card3])
-
+      
       turn.award_spoils(winner)
-
-      expect(player1.deck).to eq(deck1)
-      expect(player2.deck).to eq(deck2)
+      expect(player1.deck).to eq([card1, card2, card3, card5, card8])
+      expect(player2.deck).to eq([card4, card6, card7])
       end
     end
   end

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -42,12 +42,12 @@ RSpec.describe Turn do
         player1 = Player.new("Megan", deck1)    
         player2 = Player.new("Aurora",deck2)
         turn = Turn.new(player1, player2) 
-        
+
         expect(turn.type).to eq(:basic)
       end
     end
 
-    describe 'has a winner' do
+    describe 'has a winner and cards get shifted based on winner' do
       it "#winner" do
       card1 = Card.new(:heart, 'Jack', 11)
       card2 = Card.new(:heart, '10', 10)    
@@ -64,6 +64,31 @@ RSpec.describe Turn do
       turn = Turn.new(player1, player2) 
 
       expect(turn.winner).to eq(player1)
+      end
+
+      it 'shifts cards with #pile_cards and #award_spoils' do
+      card1 = Card.new(:heart, 'Jack', 11)
+      card2 = Card.new(:heart, '10', 10)    
+      card3 = Card.new(:heart, '9', 9)    
+      card4 = Card.new(:diamond, 'Jack', 11)    
+      card5 = Card.new(:heart, '8', 8)    
+      card6 = Card.new(:diamond, 'Queen', 12)    
+      card7 = Card.new(:heart, '3', 3)    
+      card8 = Card.new(:diamond, '2', 2)    
+      deck1 = Deck.new([card1, card2, card5, card8])    
+      deck2 = Deck.new([card3, card4, card6, card7])    
+      player1 = Player.new("Megan", deck1)    
+      player2 = Player.new("Aurora",deck2)
+      turn = Turn.new(player1, player2) 
+
+      turn.pile_cards
+
+      expect(turn.spoils_of_war).to eq([card1, card3])
+
+      turn.award_spoils(winner)
+
+      expect(player1.deck).to eq(deck1)
+      expect(player2.deck).to eq(deck2)
       end
     end
   end


### PR DESCRIPTION
This PR includes all of the Turn class test and specs for turns:

:basic. When the top cards of the players' decks are not equal
:war. When the top cards of the players' decks are equal
:mutually_assured_destruction. When the top cards are equal and the third cards of the players' decks are equal and there is no winner.
INCLUDES METHODS:

#winner. This indicates which player wins each turn if there is a winner.
#pile_of_cards. Concats cards from players deck array to @spoils_of_war array.
#award_spoils(winner). Concats @spoils_of_war array into winner's deck array.